### PR TITLE
Initial implementation of no-alloc API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,21 @@ fn main() {
 ```
 
 If you're program doesn't have the default alloc feature enabled you can use 
-`minicov::get_coverage_data_size`, to get the size required for the report and 
-`minicov::capture_coverage_to_buffer` to serialize the coverage data:
+`minicov::get_coverage_data_size`, to get the size required for the coverage data 
+and `minicov::capture_coverage_to_buffer` to serialize the coverage data:
 
 ```ignore
 fn main() {
     // ...
 
-    // with REPORT_SIZE as a const usize
-    let mut buffer: [u8; REPORT_SIZE] = [0; REPORT_SIZE];
+    // with COVERAGE_DATA_SIZE as a const usize
+    let mut buffer: [u8; COVERAGE_DATA_SIZE] = [0; COVERAGE_DATA_SIZE];
     
     let actual_size = minicov::get_coverage_data_size();
-    assert!(actual_size <= REPORT_SIZE, "Not enough space reserved for report");
+    assert!(actual_size <= COVERAGE_DATA_SIZE, "Not enough space reserved for coverage daa");
     minicov::capture_coverage_to_buffer(&mut buffer[0..actual_size]);
     
-    // Transfer report somewhere else
+    // Transfer coverage data somewhere else
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main() {
 
 If you're program doesn't have the default alloc feature enabled you can use 
 `minicov::get_coverage_data_size`, to get the size required for the report and 
-`minicov::capture_coverage_to_buffer` to serialize the report:
+`minicov::capture_coverage_to_buffer` to serialize the coverage data:
 
 ```ignore
 fn main() {

--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ fn main() {
 }
 ```
 
+If you're program doesn't have the default alloc feature enabled you can use 
+`minicov::get_coverage_data_size`, to get the size required for the report and 
+`minicov::capture_coverage_to_buffer` to serialize the report:
+
+```ignore
+fn main() {
+    // ...
+
+    // with REPORT_SIZE as a const usize
+    let mut buffer: [u8; REPORT_SIZE] = [0; REPORT_SIZE];
+    
+    let actual_size = minicov::get_coverage_data_size();
+    assert!(actual_size <= REPORT_SIZE, "Not enough space reserved for report");
+    minicov::capture_coverage_to_buffer(&mut buffer[0..actual_size]);
+    
+    // Transfer report somewhere else
+}
+```
+
 If your program is running on a different system than your build system then
 you will need to transfer this file back to your build system.
 

--- a/minicov/Cargo.toml
+++ b/minicov/Cargo.toml
@@ -10,6 +10,10 @@ keywords = ["coverage", "no_std", "llvm-cov"]
 categories = ["development-tools", "no-std", "embedded"]
 edition = "2018"
 
+[features]
+default = ["alloc"]
+alloc = []
+
 [dependencies]
 
 [build-dependencies]

--- a/minicov/src/lib.rs
+++ b/minicov/src/lib.rs
@@ -70,8 +70,10 @@
 #![warn(missing_docs)]
 #![warn(rust_2018_idioms)]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 use core::fmt;
 
@@ -106,6 +108,7 @@ fn check_version() {
 /// You should call `reset_coverage` afterwards if you intend to continue
 /// running the program so that future coverage can be merged with the returned
 /// captured coverage.
+#[cfg(feature = "alloc")]
 pub fn capture_coverage() -> Vec<u8> {
     check_version();
 
@@ -119,6 +122,32 @@ pub fn capture_coverage() -> Vec<u8> {
     }
 
     data
+}
+
+/// Returns the size required to store the serialized coverage data
+pub fn get_report_size() -> usize {
+    unsafe { __llvm_profile_get_size_for_buffer() as usize }
+}
+
+/// Captures the coverage data for the current program and writes it into the
+/// provided slice. The slice must be the correct size to hold the report so
+/// call `get_report_size` beforehand to ensure enough data is allocated.
+///
+/// The blob should be saved to a file with the `.profraw` extension, which can
+/// then be processed using the `llvm-profdata` and `llvm-cov` tools.
+///
+/// You should call `reset_coverage` afterwards if you intend to continue
+/// running the program so that future coverage can be merged with the returned
+/// captured coverage.
+pub fn capture_coverage_to_buffer(data: &mut [u8]) {
+    check_version();
+
+    let len = unsafe { __llvm_profile_get_size_for_buffer() as usize };
+    assert!(len <= data.len());
+    unsafe {
+        let ret = __llvm_profile_write_buffer(data.as_mut_ptr());
+        assert_eq!(ret, 0);
+    }
 }
 
 /// Error type returned when trying to merge incompatible coverage data.

--- a/minicov/src/lib.rs
+++ b/minicov/src/lib.rs
@@ -125,13 +125,13 @@ pub fn capture_coverage() -> Vec<u8> {
 }
 
 /// Returns the size required to store the serialized coverage data
-pub fn get_report_size() -> usize {
+pub fn get_coverage_data_size() -> usize {
     unsafe { __llvm_profile_get_size_for_buffer() as usize }
 }
 
 /// Captures the coverage data for the current program and writes it into the
 /// provided slice. The slice must be the correct size to hold the report so
-/// call `get_report_size` beforehand to ensure enough data is allocated.
+/// call `get_coverage_data_size` beforehand to ensure enough data is allocated.
 ///
 /// The blob should be saved to a file with the `.profraw` extension, which can
 /// then be processed using the `llvm-profdata` and `llvm-cov` tools.
@@ -143,7 +143,7 @@ pub fn capture_coverage_to_buffer(data: &mut [u8]) {
     check_version();
 
     let len = unsafe { __llvm_profile_get_size_for_buffer() as usize };
-    assert!(len <= data.len());
+    assert_eq!(len, data.len());
     unsafe {
         let ret = __llvm_profile_write_buffer(data.as_mut_ptr());
         assert_eq!(ret, 0);

--- a/minicov/src/lib.rs
+++ b/minicov/src/lib.rs
@@ -130,8 +130,9 @@ pub fn get_coverage_data_size() -> usize {
 }
 
 /// Captures the coverage data for the current program and writes it into the
-/// provided slice. The slice must be the correct size to hold the report so
-/// call `get_coverage_data_size` beforehand to ensure enough data is allocated.
+/// provided slice. The slice must be the correct size to hold the coverage data
+/// so call `get_coverage_data_size` beforehand to ensure enough data is
+/// allocated.
 ///
 /// The blob should be saved to a file with the `.profraw` extension, which can
 /// then be processed using the `llvm-profdata` and `llvm-cov` tools.


### PR DESCRIPTION
So some names/docs/implementaion might like to be tweaked but this is the initial implementation of the no_alloc API described in #2. 

I haven't touched minicov-test to add this in, but I can also add usage to that if desired.