### PR TITLE
fixed minicov_dealloc function signature

### DIFF
--- a/minicov/src/lib.rs
+++ b/minicov/src/lib.rs
@@ -161,8 +161,9 @@ unsafe fn minicov_alloc_zeroed(size: usize, align: usize) -> *mut u8 {
 }
 #[cfg(feature = "alloc")]
 #[no_mangle]
-unsafe fn minicov_dealloc(ptr: *mut u8, size: usize, align: usize) {
-    alloc::alloc::dealloc(ptr, Layout::from_size_align(size, align).unwrap())
+unsafe fn minicov_dealloc(ptr: *mut u8, size: usize, align: usize) -> usize {
+    alloc::alloc::dealloc(ptr, Layout::from_size_align(size, align).unwrap());
+    0
 }
 #[cfg(not(feature = "alloc"))]
 #[no_mangle]
@@ -171,7 +172,7 @@ unsafe fn minicov_alloc_zeroed(_size: usize, _align: usize) -> *mut u8 {
 }
 #[cfg(not(feature = "alloc"))]
 #[no_mangle]
-unsafe fn minicov_dealloc(_ptr: *mut u8, _size: usize, _align: usize) {}
+unsafe fn minicov_dealloc(_ptr: *mut u8, _size: usize, _align: usize) -> usize {}
 
 /// Sink into which coverage data can be written.
 ///


### PR DESCRIPTION
im not 100% sure why this is happening on my project and not your test one, but attempting to use your crate in my project leads to the following:

```
0rphon@iPhone:~/Work/Leaksignal/command/leaksignal/scripts/local$ RUSTFLAGS="-Cinstrument-coverage -Zno-profiler-runtime" cargo +nightly build --release --target wasm32-unknown-unknown -p leaksignal --features=coverage
   Compiling leaksignal v0.1.10 (/home/0rphon/Work/Leaksignal/command/leaksignal/leaksignal)
error: linking with `rust-lld` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/home/0rphon/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/0rphon/.local/bin:/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:/home/0rphon/.cargo/bin:/home/0rphon/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin" VSLANG="1033" "rust-lld" "-flavor" "wasm" "--rsp-quoting=posix" "--export" "__getrandom_custom" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "_start" "--export" "free" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "malloc" "--export" "proxy_abi_version_0_2_1" "--export" "proxy_on_configure" "--export" "proxy_on_context_create" "--export" "proxy_on_delete" "--export" "proxy_on_done" "--export" "proxy_on_downstream_connection_close" "--export" "proxy_on_downstream_data" "--export" "proxy_on_grpc_close" "--export" "proxy_on_grpc_receive" "--export" "proxy_on_grpc_receive_initial_metadata" "--export" "proxy_on_grpc_receive_trailing_metadata" "--export" "proxy_on_http_call_response" "--export" "proxy_on_log" "--export" "proxy_on_new_connection" "--export" "proxy_on_queue_ready" "--export" "proxy_on_request_body" "--export" "proxy_on_request_headers" "--export" "proxy_on_request_trailers" "--export" "proxy_on_response_body" "--export" "proxy_on_response_headers" "--export" "proxy_on_response_trailers" "--export" "proxy_on_tick" "--export" "proxy_on_upstream_connection_close" "--export" "proxy_on_upstream_data" "--export" "proxy_on_vm_start" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_runtime" "--export" "minicov_alloc_zeroed" "--export" "minicov_dealloc" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export" "__llvm_profile_filename" "--export" "__llvm_profile_raw_version" "--export=__heap_base" "--export=__data_end" "-z" "stack-size=1048576" "--stack-first" "--allow-undefined" "--fatal-warnings" "--no-demangle" "--no-entry" "/home/0rphon/Work/Leaksignal/command/leaksignal/target/wasm32-unknown-unknown/release/deps/leaksignal.leaksignal.fb1b2656-cgu.5.rcgu.o" "-L" "/home/0rphon/Work/Leaksignal/command/leaksignal/target/wasm32-unknown-unknown/release/deps" "-L" "/home/0rphon/Work/Leaksignal/command/leaksignal/target/release/deps" "-L" "/home/0rphon/Work/Leaksignal/command/leaksignal/target/wasm32-unknown-unknown/release/build/minicov-53e96598141549cc/out" "-L" "/home/0rphon/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib" "/tmp/rustcKlcw2R/libminicov-95aa8a41d2723216.rlib" "/home/0rphon/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib/libcompiler_builtins-94abef8d4c58c981.rlib" "-L" "/home/0rphon/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/wasm32-unknown-unknown/lib" "-o" "/home/0rphon/Work/Leaksignal/command/leaksignal/target/wasm32-unknown-unknown/release/deps/leaksignal.wasm" "--gc-sections" "--no-entry" "-O3"
  = note: rust-lld: error: function signature mismatch: minicov_dealloc
          >>> defined as (i32, i32, i32) -> i32 in /tmp/rustcKlcw2R/libminicov-95aa8a41d2723216.rlib(InstrProfilingValue.o)
          >>> defined as (i32, i32, i32) -> void in /home/0rphon/Work/Leaksignal/command/leaksignal/target/wasm32-unknown-unknown/release/deps/leaksignal.leaksignal.fb1b2656-cgu.5.rcgu.o
          

error: could not compile `leaksignal` (lib) due to previous error
```

all this PR does is fix the function signature. your minicov-test still passes and now my project compiles too!