### PR TITLE
Add support for x86_64-unknown-uefi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,18 @@ jobs:
         env:
           RUSTFLAGS: -Cprofile-use=output.profdata
 
+  test-uefi:
+    name: Test UEFI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: x86_64-unknown-uefi
+      # Only build minicov, since UEFI targets are no_std and
+      # minicov-test uses std.
+      - run: cargo build --target x86_64-unknown-uefi -p minicov
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/minicov/build.rs
+++ b/minicov/build.rs
@@ -1,4 +1,5 @@
 use cc::Build;
+use std::env;
 use walkdir::WalkDir;
 
 fn main() {
@@ -10,16 +11,23 @@ fn main() {
     cfg.flag("-fno-coverage-mapping");
     cfg.define("COMPILER_RT_HAS_ATOMICS", "1");
 
-    let sources = [
+    let mut sources = vec![
         "c/InstrProfiling.c",
         "c/InstrProfilingBuffer.c",
         "c/InstrProfilingInternal.c",
         "c/InstrProfilingMerge.c",
-        "c/InstrProfilingPlatformLinux.c",
         "c/InstrProfilingWriter.c",
         "c/InstrProfilingValue.c",
         "c/InstrProfilingVersionVar.c",
     ];
+
+    let target = env::var("TARGET").unwrap_or_default();
+    if target.ends_with("-uefi") {
+        cfg.define("MINICOV_UEFI", "1");
+        sources.push("c/InstrProfilingPlatformWindows.c");
+    } else {
+        sources.push("c/InstrProfilingPlatformLinux.c");
+    }
 
     for source in &sources {
         cfg.file(source);

--- a/minicov/c/InstrProfilingPlatformWindows.c
+++ b/minicov/c/InstrProfilingPlatformWindows.c
@@ -1,0 +1,73 @@
+/*===- InstrProfilingPlatformWindows.c - Profile data on Windows ----------===*\
+|*
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+|* See https://llvm.org/LICENSE.txt for license information.
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+|*
+\*===----------------------------------------------------------------------===*/
+
+#include "InstrProfiling.h"
+#include "InstrProfilingInternal.h"
+
+#if defined(_WIN32)
+
+#if defined(_MSC_VER)
+/* Merge read-write sections into .data. */
+#pragma comment(linker, "/MERGE:.lprfc=.data")
+#pragma comment(linker, "/MERGE:.lprfd=.data")
+#pragma comment(linker, "/MERGE:.lprfv=.data")
+#pragma comment(linker, "/MERGE:.lprfnd=.data")
+/* Do *NOT* merge .lprfn and .lcovmap into .rdata. llvm-cov must be able to find
+ * after the fact.
+ */
+
+/* Allocate read-only section bounds. */
+#pragma section(".lprfn$A", read)
+#pragma section(".lprfn$Z", read)
+
+/* Allocate read-write section bounds. */
+#pragma section(".lprfd$A", read, write)
+#pragma section(".lprfd$Z", read, write)
+#pragma section(".lprfc$A", read, write)
+#pragma section(".lprfc$Z", read, write)
+#pragma section(".lorderfile$A", read, write)
+#pragma section(".lprfnd$A", read, write)
+#pragma section(".lprfnd$Z", read, write)
+#endif
+
+__llvm_profile_data COMPILER_RT_SECTION(".lprfd$A") DataStart = {0};
+__llvm_profile_data COMPILER_RT_SECTION(".lprfd$Z") DataEnd = {0};
+
+const char COMPILER_RT_SECTION(".lprfn$A") NamesStart = '\0';
+const char COMPILER_RT_SECTION(".lprfn$Z") NamesEnd = '\0';
+
+char COMPILER_RT_SECTION(".lprfc$A") CountersStart;
+char COMPILER_RT_SECTION(".lprfc$Z") CountersEnd;
+uint32_t COMPILER_RT_SECTION(".lorderfile$A") OrderFileStart;
+
+ValueProfNode COMPILER_RT_SECTION(".lprfnd$A") VNodesStart;
+ValueProfNode COMPILER_RT_SECTION(".lprfnd$Z") VNodesEnd;
+
+const __llvm_profile_data *__llvm_profile_begin_data(void) {
+  return &DataStart + 1;
+}
+const __llvm_profile_data *__llvm_profile_end_data(void) { return &DataEnd; }
+
+const char *__llvm_profile_begin_names(void) { return &NamesStart + 1; }
+const char *__llvm_profile_end_names(void) { return &NamesEnd; }
+
+char *__llvm_profile_begin_counters(void) { return &CountersStart + 1; }
+char *__llvm_profile_end_counters(void) { return &CountersEnd; }
+uint32_t *__llvm_profile_begin_orderfile(void) { return &OrderFileStart; }
+
+ValueProfNode *__llvm_profile_begin_vnodes(void) { return &VNodesStart + 1; }
+ValueProfNode *__llvm_profile_end_vnodes(void) { return &VNodesEnd; }
+
+ValueProfNode *CurrentVNode = &VNodesStart + 1;
+ValueProfNode *EndVNode = &VNodesEnd;
+
+COMPILER_RT_VISIBILITY int __llvm_write_binary_ids(__attribute__((unused)) ProfDataWriter *Writer) {
+  return 0;
+}
+
+#endif

--- a/minicov/c/InstrProfilingPort.h
+++ b/minicov/c/InstrProfilingPort.h
@@ -61,7 +61,7 @@
 #endif
 
 #if COMPILER_RT_HAS_ATOMICS == 1
-#ifdef _WIN32
+#if defined(_WIN32) && MINICOV_UEFI != 1
 #include <windows.h>
 #if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
@@ -82,10 +82,17 @@
                                     (LONG)sizeof(DomType) * PtrIncr)
 #endif
 #else /* !defined(_WIN32) */
+
+#if MINICOV_UEFI == 1 && defined(_WIN64)
+#define COMPILER_RT_PTR_FETCH_ADD_TYPE long long
+#else
+#define COMPILER_RT_PTR_FETCH_ADD_TYPE long
+#endif
+
 #define COMPILER_RT_BOOL_CMPXCHG(Ptr, OldV, NewV)                              \
   __sync_bool_compare_and_swap(Ptr, OldV, NewV)
 #define COMPILER_RT_PTR_FETCH_ADD(DomType, PtrVar, PtrIncr)                    \
-  (DomType *)__sync_fetch_and_add((long *)&PtrVar, sizeof(DomType) * PtrIncr)
+  (DomType *)__sync_fetch_and_add((COMPILER_RT_PTR_FETCH_ADD_TYPE *)&PtrVar, sizeof(DomType) * PtrIncr)
 #endif
 #else /* COMPILER_RT_HAS_ATOMICS != 1 */
 #define COMPILER_RT_BOOL_CMPXCHG(Ptr, OldV, NewV)                              \
@@ -108,7 +115,7 @@
   (((ch) == DIR_SEPARATOR) || ((ch) == DIR_SEPARATOR_2))
 #endif /* DIR_SEPARATOR_2 */
 
-#if defined(_WIN32)
+#if defined(_WIN32) && MINICOV_UEFI != 1
 #include <windows.h>
 static inline size_t getpagesize() {
   SYSTEM_INFO S;


### PR DESCRIPTION
UEFI executables are PEs, so they need InstrProfilingPlatformWindows.c instead of c/InstrProfilingPlatformLinux.c.
    
A few other minor changes are needed, gated behind a `MINICOV_UEFI` define, to avoid including windows.h ~~and to define `__chkstk_ms`~~.

Also add a minimal CI job that just checks that minicov builds on that target. The minicov-test binary requires `std`, while the UEFI targets are `no_std`. And even if it did build, running it would require QEMU.