### PR TITLE
Add define for memcmp

### DIFF
--- a/minicov/c/InstrProfilingPort.h
+++ b/minicov/c/InstrProfilingPort.h
@@ -159,6 +159,7 @@ static inline size_t getpagesize() {
 #include <stdint.h>
 #include <stdalign.h>
 
+#define memcmp __builtin_memcmp
 #define memset __builtin_memset
 #define memcpy __builtin_memcpy
 #define memmove __builtin_memmove


### PR DESCRIPTION
As of 8b3c9fb8079e28eafb62c5611f865fbcebc8b26e, InstrProfilingPlatformWindows.c uses memcmp. Define memcmp via a macro to avoid a "call to undeclared library function" error.