### PR TITLE
Fix profiling broken on wasm since Rust 1.87 (LLVM 20)

### DIFF
--- a/minicov/c/InstrProfilingPlatformLinux.c
+++ b/minicov/c/InstrProfilingPlatformLinux.c
@@ -8,7 +8,7 @@
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__Fuchsia__) || \
     (defined(__sun__) && defined(__svr4__)) || defined(__NetBSD__) || \
-    defined(_AIX)
+    defined(_AIX) || defined(__wasm__)
 
 #include "InstrProfiling.h"
 #include "InstrProfilingInternal.h"

--- a/minicov/c/InstrProfilingPlatformOther.c
+++ b/minicov/c/InstrProfilingPlatformOther.c
@@ -8,7 +8,8 @@
 
 #if !defined(__APPLE__) && !defined(__linux__) && !defined(__FreeBSD__) &&     \
     !defined(__Fuchsia__) && !(defined(__sun__) && defined(__svr4__)) &&       \
-    !defined(__NetBSD__) && !defined(_WIN32) && !defined(_AIX)
+    !defined(__NetBSD__) && !defined(_WIN32) && !defined(_AIX) &&              \
+    !defined(__wasm__)
 
 #include <stddef.h>
 


### PR DESCRIPTION
Introduced by https://github.com/llvm/llvm-project/pull/111332

resolves https://github.com/Amanieu/minicov/issues/31 https://github.com/wasm-bindgen/wasm-bindgen/issues/4797

